### PR TITLE
feat: 빈 카트일 경우 restaurant 필드를 추가할 메뉴의 가게로 초기화

### DIFF
--- a/src/cart/CartService.java
+++ b/src/cart/CartService.java
@@ -2,6 +2,7 @@ package cart;
 
 import java.util.List;
 import menu.Menu;
+import restaurant.Restaurant;
 import restaurant.RestaurantDAO;
 import user.UserDAO;
 
@@ -13,7 +14,7 @@ public class CartService {
     public boolean addMenu(Menu menu, String userId) {
         Cart currentCart = getCartByUserId(userId);
         if (currentCart.getRestaurant() == null) {
-            // TODO : 빈 카트일 경우 cart의 restaurant 필드를 해당 메뉴의 가게로 초기화
+            updateRestaurantField(currentCart, menu.getRestaurantName());
         }
 
         if (isEqualRestaurant(menu, currentCart)) {
@@ -23,7 +24,23 @@ public class CartService {
         }
         return false;
     }
-    
+
+    public Restaurant findRestaurantByName(String name) {
+        List<Restaurant> restaurants = restaurantDAO.findAll();
+        for (Restaurant restaurant : restaurants) {
+            if (restaurant.getName().equals(name)) {
+                return restaurant;
+            }
+        }
+        return null;
+    }
+
+    public void updateRestaurantField(Cart currentCart, String restaurantName) {
+        currentCart.setRestaurant(
+                findRestaurantByName(restaurantName)
+        );
+    }
+
     public boolean isEqualRestaurant(Menu menu, Cart cart) {
         String restaurantOfNewMenu = menu.getRestaurantName();
         String restaurantOfCartItems = cart


### PR DESCRIPTION
### PR 타입
- [x] 기능 추가
- [] 기능 수정
- [] 기능 삭제
- [] 버그 수정
- [] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
feat/cart -> main

### 변경 사항
- 빈 카트일 경우 Cart의 restaurant 필드를 새로 넣는 메뉴의 가게로 초기화 하는 메서드 추가
   - menu에 담긴 restaurant 정보는 String이므로  restaurant의 hashMap에서 순회해서 찾았습니다